### PR TITLE
e2e: Send account invites to a real email address

### DIFF
--- a/e2e/specs/accept-invite.e2e-spec.ts
+++ b/e2e/specs/accept-invite.e2e-spec.ts
@@ -15,7 +15,7 @@ import {getApiEndpoint} from '../utils/env.utils';
 var supertest = require('supertest');
 var crypto = require('crypto');
 
-let newEmail = `e2e${new Date().getTime()}@sixcrm.com`;
+let newEmail = `e2e-accept-invite+${new Date().getTime()}@sixcrm.com`;
 let newPassword = '123456789';
 
 describe('Accept Invite', function () {


### PR DESCRIPTION
Resolves issue with AWS SES emails bouncing too frequently.

/cc @nikolabtt @carlitoescobar 